### PR TITLE
Fixed Clang path + formatting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,16 @@ FROM ubuntu:16.04
 # Make sure the image is updated, install some prerequisites,
 # Download the latest version of Clang (official binary) for Ubuntu
 # Extract the archive and add Clang to the PATH
-RUN apt update && apt install -y \
-  xz-utils \
-  build-essential \
-  curl \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -SL http://releases.llvm.org/7.0.0/clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz \
-  | tar -xJC . && \
-  mv clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04 clang_7.0.0 && \
-  echo 'export PATH=/clang_7.0.0/bin:$PATH' >> ~/.bashrc && \
-  echo 'export LD_LIBRARY_PATH=/clang_7.0.0/lib:LD_LIBRARY_PATH' >> ~/.bashrc
+RUN apt-get update \ 
+    && apt-get install -y \
+        xz-utils \
+        build-essential \
+        curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -SL http://releases.llvm.org/7.0.0/clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz | tar -xJC . \
+    && mv clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04 /clang_7.0.0 \
+    && echo 'export PATH=/clang_7.0.0/bin:$PATH' >> ~/.bashrc \
+    && echo 'export LD_LIBRARY_PATH=/clang_7.0.0/lib:LD_LIBRARY_PATH' >> ~/.bashrc
 
 # Start from a Bash prompt
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
* Changed `clang_7.0.0` to `/clang_7.0.0` in the mv command to fit with the export commands.
* Used `apt-get` instead of  `apt` to remove the annoying warning.
  * WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
* Format with 4 spaces and start lines with &&.